### PR TITLE
Add simple Postgres connection

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,10 @@ import torch
 import os
 from werkzeug.utils import secure_filename
 import uuid
+from dotenv import load_dotenv
+from models.db import test_connection
+
+load_dotenv()
 
 # Initialize Flask app
 app = Flask(__name__)
@@ -18,6 +22,14 @@ def allowed_file(filename):
 @app.route('/')
 def index():
     return 'YOLOv5 Flask Backend is Running'
+
+
+@app.route('/test-db')
+def test_db():
+    """Check database connectivity by running a simple query."""
+    if test_connection():
+        return jsonify({'connected': True})
+    return jsonify({'connected': False}), 500
 
 
 if __name__ == '__main__':

--- a/models/db.py
+++ b/models/db.py
@@ -1,0 +1,28 @@
+import os
+import psycopg2
+
+
+def get_connection():
+    """Create and return a new PostgreSQL connection using environment variables."""
+    return psycopg2.connect(
+        host=os.getenv("POSTGRES_HOST", "localhost"),
+        port=os.getenv("POSTGRES_PORT", "5432"),
+        dbname=os.getenv("POSTGRES_DB", "postgres"),
+        user=os.getenv("POSTGRES_USER", "postgres"),
+        password=os.getenv("POSTGRES_PASSWORD", "postgres"),
+    )
+
+
+def test_connection() -> bool:
+    """Attempt a simple query to ensure the database connection works."""
+    try:
+        conn = get_connection()
+        cur = conn.cursor()
+        cur.execute("SELECT 1;")
+        cur.fetchone()
+        cur.close()
+        conn.close()
+        return True
+    except Exception as exc:
+        print(f"Database connection failed: {exc}")
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Flask>=2.3
+Flask-JWT-Extended>=4.6
+python-dotenv>=1.0
+psycopg2-binary>=2.9
+Flask-Migrate>=4.0
+Flask-CORS>=3.0
+gunicorn>=21.2
+-r yolov5/requirements.txt


### PR DESCRIPTION
## Summary
- create `models/db.py` with helpers to connect to Postgres
- load `.env` values in `app.py`
- add `/test-db` route to verify the database connection

## Testing
- `python -m py_compile app.py models/db.py`

------
https://chatgpt.com/codex/tasks/task_b_68681bbed7908327b9705a0c923aa853