### PR TITLE
Add user auth routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,9 +3,21 @@ import torch
 import os
 from werkzeug.utils import secure_filename
 import uuid
+from dotenv import load_dotenv
+from flask_jwt_extended import JWTManager
+from models.db import test_connection
+from models.user_model import init_db
+from routes.user_route import user_bp
+
+load_dotenv()
 
 # Initialize Flask app
 app = Flask(__name__)
+app.config["JWT_SECRET_KEY"] = os.getenv("JWT_SECRET_KEY", "super-secret")
+jwt = JWTManager(app)
+
+init_db()
+app.register_blueprint(user_bp)
 
 # Upload settings
 UPLOAD_FOLDER = 'uploads'
@@ -18,6 +30,14 @@ def allowed_file(filename):
 @app.route('/')
 def index():
     return 'YOLOv5 Flask Backend is Running'
+
+
+@app.route('/test-db')
+def test_db():
+    """Check database connectivity by running a simple query."""
+    if test_connection():
+        return jsonify({'connected': True})
+    return jsonify({'connected': False}), 500
 
 
 if __name__ == '__main__':

--- a/models/db.py
+++ b/models/db.py
@@ -1,0 +1,28 @@
+import os
+import psycopg2
+
+
+def get_connection():
+    """Create and return a new PostgreSQL connection using environment variables."""
+    return psycopg2.connect(
+        host=os.getenv("POSTGRES_HOST", "localhost"),
+        port=os.getenv("POSTGRES_PORT", "5432"),
+        dbname=os.getenv("POSTGRES_DB", "postgres"),
+        user=os.getenv("POSTGRES_USER", "postgres"),
+        password=os.getenv("POSTGRES_PASSWORD", "postgres"),
+    )
+
+
+def test_connection() -> bool:
+    """Attempt a simple query to ensure the database connection works."""
+    try:
+        conn = get_connection()
+        cur = conn.cursor()
+        cur.execute("SELECT 1;")
+        cur.fetchone()
+        cur.close()
+        conn.close()
+        return True
+    except Exception as exc:
+        print(f"Database connection failed: {exc}")
+        return False

--- a/models/user_model.py
+++ b/models/user_model.py
@@ -1,0 +1,91 @@
+import psycopg2
+from psycopg2 import sql
+from .db import get_connection
+
+
+def init_db():
+    """Create the users table if it doesn't exist."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id SERIAL PRIMARY KEY,
+            email TEXT UNIQUE NOT NULL,
+            password TEXT NOT NULL
+        );
+        """
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+
+
+def create_user(email: str, password: str) -> int:
+    """Insert a new user and return the user id."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO users (email, password) VALUES (%s, %s) RETURNING id;",
+        (email, password),
+    )
+    user_id = cur.fetchone()[0]
+    conn.commit()
+    cur.close()
+    conn.close()
+    return user_id
+
+
+def get_user_by_id(user_id: int):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT id, email, password FROM users WHERE id = %s;", (user_id,))
+    row = cur.fetchone()
+    cur.close()
+    conn.close()
+    return row
+
+
+def get_user_by_email(email: str):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT id, email, password FROM users WHERE email = %s;", (email,))
+    row = cur.fetchone()
+    cur.close()
+    conn.close()
+    return row
+
+
+def update_user(user_id: int, email: str = None, password: str = None) -> bool:
+    """Update email and/or password for the specified user."""
+    if email is None and password is None:
+        return False
+    fields = []
+    values = []
+    if email is not None:
+        fields.append("email = %s")
+        values.append(email)
+    if password is not None:
+        fields.append("password = %s")
+        values.append(password)
+    values.append(user_id)
+    conn = get_connection()
+    cur = conn.cursor()
+    query = "UPDATE users SET " + ", ".join(fields) + " WHERE id = %s;"
+    cur.execute(query, values)
+    updated = cur.rowcount > 0
+    conn.commit()
+    cur.close()
+    conn.close()
+    return updated
+
+
+def delete_user(user_id: int) -> bool:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM users WHERE id = %s;", (user_id,))
+    deleted = cur.rowcount > 0
+    conn.commit()
+    cur.close()
+    conn.close()
+    return deleted

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+Flask>=2.3
+Flask-JWT-Extended>=4.6
+python-dotenv>=1.0
+psycopg2-binary>=2.9
+Flask-Migrate>=4.0
+Flask-CORS>=3.0
+gunicorn>=21.2
+bcrypt>=4.1
+-r yolov5/requirements.txt
+

--- a/routes/user_route.py
+++ b/routes/user_route.py
@@ -1,0 +1,42 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import create_access_token
+import bcrypt
+
+from models.user_model import create_user, get_user_by_email
+
+user_bp = Blueprint('user', __name__)
+
+@user_bp.route('/signup', methods=['POST'])
+def signup():
+    data = request.get_json() or {}
+    email = data.get('email')
+    password = data.get('password')
+    if not email or not password:
+        return jsonify({'message': 'Email and password required'}), 400
+    hashed = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt())
+    try:
+        user_id = create_user(email, hashed.decode('utf-8'))
+        return jsonify({'id': user_id, 'email': email}), 201
+    except Exception as exc:
+        return jsonify({'message': 'User creation failed'}), 400
+
+
+@user_bp.route('/signin', methods=['POST'])
+def signin():
+    data = request.get_json() or {}
+    email = data.get('email')
+    password = data.get('password')
+    if not email or not password:
+        return jsonify({'message': 'Email and password required'}), 400
+    try:
+        user = get_user_by_email(email)
+        if not user:
+            return jsonify({'message': 'Invalid credentials'}), 401
+        user_id, _, hashed_password = user
+        if not bcrypt.checkpw(password.encode('utf-8'), hashed_password.encode('utf-8')):
+            return jsonify({'message': 'Invalid credentials'}), 401
+        access_token = create_access_token(identity=user_id)
+        return jsonify({'access_token': access_token}), 200
+    except Exception:
+        return jsonify({'message': 'Authentication failed'}), 400
+


### PR DESCRIPTION
## Summary
- configure JWT and initialize DB and blueprints in `app.py`
- implement `/signup` and `/signin` routes using bcrypt and JWT
- list bcrypt package in `requirements.txt`

## Testing
- `python -m py_compile app.py models/db.py models/user_model.py routes/user_route.py`
- `pip install -r requirements.txt` *(fails: operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_68681bbed7908327b9705a0c923aa853